### PR TITLE
Override background-color property of jr-crop class over existing propery of ionic modal class

### DIFF
--- a/dist/jr-crop.css
+++ b/dist/jr-crop.css
@@ -1,5 +1,5 @@
 .jr-crop {
-  background-color: #000;
+  background-color: #000 !important;
   overflow: hidden; }
 
 .jr-crop-center-container {

--- a/src/jr-crop.scss
+++ b/src/jr-crop.scss
@@ -1,7 +1,7 @@
 @import "../bower/ionic/scss/mixins";
 
 .jr-crop {
-  background-color: #000;
+  background-color: #000 !important;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Problem that this pull request is addressing
The ionic's modal class's background property is overriding jr-crop's background property.

## Solution
Used `!important` for background-color property. [As suggested here](http://stackoverflow.com/a/20955958/602165)