### PR TITLE
changed devDependencies to dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "ionic-crop"
   ],
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "ionic": "1.1.1",
     "blueimp-canvas-to-blob": "~2.2.0"
   }


### PR DESCRIPTION
this allows me (and hopefully others as well) to use this plugin in conjunction with [main-bower-files](https://github.com/ck86/main-bower-files) without having to mannually override the dependencies of this component to ensure that everything is properly pulled into the build.

Currently, I have to include the following to make my build work

``` json
{
  ...
  "overrides": {
    "jr-crop" : {
      "dependencies":{
        "ionic" : "*",
        "blueimp-canvas-to-blob":"*"
      }
    }
}
```
